### PR TITLE
[feat] 카카오 소셜 로그인

### DIFF
--- a/bookiary-application/build.gradle
+++ b/bookiary-application/build.gradle
@@ -2,5 +2,8 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    // Spring Data JPA for @Transational
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation project(':bookiary-domain')
 }

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/AuthService.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/AuthService.java
@@ -1,5 +1,7 @@
 package oz.bookiarybacked.application.auth;
 
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
 import java.net.URI;
 
 import org.springframework.stereotype.Service;
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.application.auth.dto.TokenPair;
+import oz.bookiarybacked.application.auth.dto.request.ReissueTokenReq;
 import oz.bookiarybacked.application.auth.dto.response.LoginRes;
 import oz.bookiarybacked.domain.auth.dto.OAuthUser;
 import oz.bookiarybacked.domain.auth.model.AuthProviderType;
@@ -17,12 +20,15 @@ import oz.bookiarybacked.domain.auth.service.JwtManager;
 import oz.bookiarybacked.domain.auth.service.OAuthManager;
 import oz.bookiarybacked.domain.auth.service.OAuthManagerFactory;
 import oz.bookiarybacked.domain.user.model.User;
+import oz.bookiarybacked.domain.user.service.UserDomainService;
+import oz.bookiarybacked.exception.TokenValidationFailException;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AuthService {
 	private final AuthDomainService authDomainService;
+	private final UserDomainService userDomainService;
 	private final OAuthManagerFactory oAuthManagerFactory;
 	private final JwtManager jwtManager;
 	private final RefreshTokenRepository refreshTokenRepository;
@@ -42,6 +48,34 @@ public class AuthService {
 		User user = authDomainService.getUser(oAuthUser);
 
 		// Step 3. 북단장 자체 AT/RT 발급
+		return LoginRes.from(createTokenPair(user));
+	}
+
+	@Transactional
+	public LoginRes reissue(ReissueTokenReq request) {
+		// Step 1. Refresh Token 파싱
+		String refreshToken = request.refreshToken();
+		Long userId = jwtManager.getUserId(refreshToken);
+
+		// Step 2. 기존 Refresh Token 조회
+		RefreshToken oldToken = refreshTokenRepository.findByUserId(userId);
+
+		// Step 3. Refresh Token 검증
+		oldToken.validate(refreshToken);
+
+		// Step 4. 만료 여부 확인
+		if (oldToken.isExpired()) {
+			refreshTokenRepository.delete(oldToken);
+			throw new TokenValidationFailException(EXPIRED_TOKEN);
+		}
+
+		// Step 4. 기존 Refresh Token 삭제
+		refreshTokenRepository.delete(oldToken);
+
+		// Step 5. 사용자 조회
+		User user = userDomainService.getById(userId);
+
+		// Step 6. AT/RT 재발급
 		return LoginRes.from(createTokenPair(user));
 	}
 

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/AuthService.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/AuthService.java
@@ -1,0 +1,61 @@
+package oz.bookiarybacked.application.auth;
+
+import java.net.URI;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.application.auth.dto.TokenPair;
+import oz.bookiarybacked.application.auth.dto.response.LoginRes;
+import oz.bookiarybacked.domain.auth.dto.OAuthUser;
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+import oz.bookiarybacked.domain.auth.model.RefreshToken;
+import oz.bookiarybacked.domain.auth.repository.RefreshTokenRepository;
+import oz.bookiarybacked.domain.auth.service.AuthDomainService;
+import oz.bookiarybacked.domain.auth.service.JwtManager;
+import oz.bookiarybacked.domain.auth.service.OAuthManager;
+import oz.bookiarybacked.domain.auth.service.OAuthManagerFactory;
+import oz.bookiarybacked.domain.user.model.User;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+	private final AuthDomainService authDomainService;
+	private final OAuthManagerFactory oAuthManagerFactory;
+	private final JwtManager jwtManager;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	public URI getLoginUrl(String providerType) {
+		OAuthManager oauthManager = oAuthManagerFactory.getOAuthManager(AuthProviderType.from(providerType));
+		return oauthManager.getLoginPageUrl();
+	}
+
+	@Transactional
+	public LoginRes socialLogin(String providerType, String code) {
+		// Step 1. 자원 서버에서 사용자 정보를 가져옴
+		OAuthManager oauthManager = oAuthManagerFactory.getOAuthManager(AuthProviderType.from(providerType));
+		OAuthUser oAuthUser = oauthManager.retrieveOAuthUser(code);
+
+		// Step 2. 회원 조회 (최초 로그인인 경우 회원가입)
+		User user = authDomainService.getUser(oAuthUser);
+
+		// Step 3. 북단장 자체 AT/RT 발급
+		return LoginRes.from(createTokenPair(user));
+	}
+
+	private TokenPair createTokenPair(User user) {
+		String accessToken = jwtManager.generateAccessToken(user);
+		String refreshToken = jwtManager.generateRefreshToken(user);
+
+		storeRefreshToken(refreshToken, user.getId());
+
+		return new TokenPair(accessToken, refreshToken);
+	}
+
+	private void storeRefreshToken(String token, Long userId) {
+		RefreshToken refreshToken = RefreshToken.of(userId, token, jwtManager.getExpiredAt(token));
+		refreshTokenRepository.save(refreshToken);
+	}
+}

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/TokenPair.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/TokenPair.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.application.auth.dto;
+
+public record TokenPair(
+	String accessToken,
+	String refreshToken
+) {
+
+}

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/request/ReissueTokenReq.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/request/ReissueTokenReq.java
@@ -1,0 +1,6 @@
+package oz.bookiarybacked.application.auth.dto.request;
+
+public record ReissueTokenReq(
+	String refreshToken
+) {
+}

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/response/LoginRes.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/auth/dto/response/LoginRes.java
@@ -1,0 +1,17 @@
+package oz.bookiarybacked.application.auth.dto.response;
+
+import lombok.Builder;
+import oz.bookiarybacked.application.auth.dto.TokenPair;
+
+@Builder
+public record LoginRes(
+	String accessToken,
+	String refreshToken
+) {
+	public static LoginRes from(TokenPair tokenPair) {
+		return LoginRes.builder()
+			.accessToken(tokenPair.accessToken())
+			.refreshToken(tokenPair.refreshToken())
+			.build();
+	}
+}

--- a/bookiary-domain/build.gradle
+++ b/bookiary-domain/build.gradle
@@ -8,5 +8,10 @@ dependencies {
     // PostgreSQL
     implementation 'org.postgresql:postgresql'
 
+    // Jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     runtimeOnly project(':bookiary-infrastructure')
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/config/PropertyConfig.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/config/PropertyConfig.java
@@ -1,0 +1,9 @@
+package oz.bookiarybacked.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan
+public class PropertyConfig {
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/config/properties/JwtProperties.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/config/properties/JwtProperties.java
@@ -1,0 +1,13 @@
+package oz.bookiarybacked.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("jwt")
+public record JwtProperties(
+	String issuer,
+	String secretKey,
+	int expiresIn,
+	int refreshExpiresIn
+) {
+
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/dto/OAuthUser.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/dto/OAuthUser.java
@@ -1,0 +1,13 @@
+package oz.bookiarybacked.domain.auth.dto;
+
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+
+public record OAuthUser(
+	AuthProviderType providerType,
+	String providerId
+) {
+
+	public static OAuthUser of(AuthProviderType providerType, String providerId) {
+		return new OAuthUser(providerType, providerId);
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/AuthProvider.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/AuthProvider.java
@@ -1,0 +1,48 @@
+package oz.bookiarybacked.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oz.bookiarybacked.domain.auth.dto.OAuthUser;
+import oz.bookiarybacked.domain.user.model.User;
+
+@Entity
+@Table(name = "auth_provider")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthProvider {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private AuthProviderType type;
+
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
+
+	public static AuthProvider of(OAuthUser oAuthUser, User user) {
+		return AuthProvider.builder()
+			.userId(user.getId())
+			.type(oAuthUser.providerType())
+			.providerId(oAuthUser.providerId())
+			.build();
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/AuthProviderType.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/AuthProviderType.java
@@ -1,0 +1,9 @@
+package oz.bookiarybacked.domain.auth.model;
+
+public enum AuthProviderType {
+	KAKAO;
+
+	public static AuthProviderType from(String provider) {
+		return AuthProviderType.valueOf(provider.toUpperCase());
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/RefreshToken.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/RefreshToken.java
@@ -1,5 +1,7 @@
 package oz.bookiarybacked.domain.auth.model;
 
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import oz.bookiarybacked.exception.TokenValidationFailException;
 
 @Entity
 @Table(name = "refresh_token")
@@ -39,5 +42,15 @@ public class RefreshToken {
 			.token(token)
 			.expireAt(expireAt)
 			.build();
+	}
+
+	public void validate(String refreshToken) {
+		if (!token.equals(refreshToken)) {
+			throw new TokenValidationFailException(INVALID_TOKEN);
+		}
+	}
+
+	public boolean isExpired() {
+		return System.currentTimeMillis() > expireAt;
 	}
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/RefreshToken.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/model/RefreshToken.java
@@ -1,0 +1,43 @@
+package oz.bookiarybacked.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "token")
+	private String token;
+
+	@Column(name = "expire_at")
+	private Long expireAt;
+
+	public static RefreshToken of(Long userId, String token, Long expireAt) {
+		return RefreshToken.builder()
+			.userId(userId)
+			.token(token)
+			.expireAt(expireAt)
+			.build();
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/AuthRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,21 @@
+package oz.bookiarybacked.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import oz.bookiarybacked.domain.auth.model.AuthProvider;
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+import oz.bookiarybacked.domain.user.model.User;
+
+public interface AuthRepository extends JpaRepository<AuthProvider, Long> {
+	boolean existsByTypeAndProviderId(AuthProviderType type, String providerId);
+
+	@Query("""
+		SELECT u 
+		FROM User u 
+		JOIN AuthProvider o ON o.type = :type AND o.providerId = :providerId AND o.userId = u.id
+		""")
+	Optional<User> findUserByTypeAndProviderId(AuthProviderType type, String providerId);
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/RefreshTokenRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/RefreshTokenRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import oz.bookiarybacked.domain.auth.model.RefreshToken;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	RefreshToken findByUserId(Long userId);
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/RefreshTokenRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.bookiarybacked.domain.auth.model.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/AuthDomainService.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/AuthDomainService.java
@@ -1,0 +1,33 @@
+package oz.bookiarybacked.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.domain.auth.dto.OAuthUser;
+import oz.bookiarybacked.domain.auth.model.AuthProvider;
+import oz.bookiarybacked.domain.auth.repository.AuthRepository;
+import oz.bookiarybacked.domain.user.model.User;
+import oz.bookiarybacked.domain.user.repository.UserRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthDomainService {
+
+	private final AuthRepository authRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public User getUser(OAuthUser oAuthUser) {
+		return authRepository.findUserByTypeAndProviderId(oAuthUser.providerType(), oAuthUser.providerId())
+			.orElseGet(() -> signup(oAuthUser));
+	}
+
+	private User signup(OAuthUser oAuthUser) {
+		User user = userRepository.save(User.signUp());
+		AuthProvider authProvider = AuthProvider.of(oAuthUser, user);
+		authRepository.save(authProvider);
+		return user;
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/JwtManager.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/JwtManager.java
@@ -1,0 +1,78 @@
+package oz.bookiarybacked.domain.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import oz.bookiarybacked.config.properties.JwtProperties;
+import oz.bookiarybacked.domain.user.model.User;
+import oz.bookiarybacked.exception.ErrorMessages;
+import oz.bookiarybacked.exception.TokenValidationFailException;
+
+@Component
+public class JwtManager {
+	private static final long MILLISECONDS_PER_MINUTE = 60 * 1000L;
+	public static final String USER_ID_CLAIM = "user_id";
+	private final String issuer;
+	private final SecretKey secretKey;
+	private final long expiresIn;
+	private final long refreshExpiresIn;
+
+	public JwtManager(JwtProperties jwtProperties) {
+		issuer = jwtProperties.issuer();
+		secretKey = Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8));
+		expiresIn = jwtProperties.expiresIn() * MILLISECONDS_PER_MINUTE;
+		refreshExpiresIn = jwtProperties.refreshExpiresIn() * MILLISECONDS_PER_MINUTE;
+	}
+
+	public String generateAccessToken(User user) {
+		return generateToken(user, expiresIn);
+	}
+
+	public String generateRefreshToken(User user) {
+		return generateToken(user, refreshExpiresIn);
+	}
+
+	public Long getUserId(String token) {
+		return parseClaims(token).get(USER_ID_CLAIM, Long.class);
+	}
+
+	public Long getExpiredAt(String token) {
+		return parseClaims(token).getExpiration().getTime();
+	}
+
+	private String generateToken(User user, long expiredAfter) {
+		Instant now = Instant.now();
+		Instant expiredAt = now.plusMillis(expiredAfter);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setIssuedAt(Date.from(now))
+			.setExpiration(Date.from(expiredAt))
+			.claim(USER_ID_CLAIM, user.getId())
+			.signWith(secretKey)
+			.compact();
+	}
+
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new TokenValidationFailException(ErrorMessages.EXPIRED_TOKEN);
+		} catch (Exception e) {
+			throw new TokenValidationFailException(ErrorMessages.INVALID_TOKEN);
+		}
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/OAuthManager.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/OAuthManager.java
@@ -1,0 +1,14 @@
+package oz.bookiarybacked.domain.auth.service;
+
+import java.net.URI;
+
+import oz.bookiarybacked.domain.auth.dto.OAuthUser;
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+
+public interface OAuthManager {
+	URI getLoginPageUrl();
+
+	OAuthUser retrieveOAuthUser(String code);
+
+	AuthProviderType getType();
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/OAuthManagerFactory.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/auth/service/OAuthManagerFactory.java
@@ -1,0 +1,7 @@
+package oz.bookiarybacked.domain.auth.service;
+
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+
+public interface OAuthManagerFactory {
+	OAuthManager getOAuthManager(AuthProviderType type);
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
@@ -1,0 +1,35 @@
+package oz.bookiarybacked.domain.user.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "nickname")
+	private String nickname;
+
+	public static User signUp() {
+		return User.builder()
+			.build();
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/repository/UserRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.bookiarybacked.domain.user.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/service/UserDomainService.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/service/UserDomainService.java
@@ -1,8 +1,11 @@
 package oz.bookiarybacked.domain.user.service;
 
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.domain.user.model.User;
 import oz.bookiarybacked.domain.user.repository.UserRepository;
@@ -13,8 +16,8 @@ import oz.bookiarybacked.domain.user.repository.UserRepository;
 public class UserDomainService {
 	private final UserRepository userRepository;
 
-	@Transactional
-	public User signup() {
-		return userRepository.save(User.signUp());
+	public User getById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 	}
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/service/UserDomainService.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/service/UserDomainService.java
@@ -1,0 +1,20 @@
+package oz.bookiarybacked.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.domain.user.model.User;
+import oz.bookiarybacked.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserDomainService {
+	private final UserRepository userRepository;
+
+	@Transactional
+	public User signup() {
+		return userRepository.save(User.signUp());
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
@@ -5,7 +5,11 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ErrorMessages {
+	// Auth
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 	public static final String UNSUPPORTED_OAUTH_TYPE = "지원하지 않는 소셜 로그인 타입입니다.";
+
+	// User
+	public static final String USER_NOT_FOUND = "해당 식별자를 가진 사용자가 존재하지 않습니다.";
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
@@ -1,0 +1,11 @@
+package oz.bookiarybacked.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ErrorMessages {
+	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
+	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+	public static final String UNSUPPORTED_OAUTH_TYPE = "지원하지 않는 소셜 로그인 타입입니다.";
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/exception/ErrorMessages.java
@@ -9,6 +9,7 @@ public final class ErrorMessages {
 	public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
 	public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 	public static final String UNSUPPORTED_OAUTH_TYPE = "지원하지 않는 소셜 로그인 타입입니다.";
+	public static final String LOGIN_REQUIRED = "로그인이 필요한 요청입니다.";
 
 	// User
 	public static final String USER_NOT_FOUND = "해당 식별자를 가진 사용자가 존재하지 않습니다.";

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/exception/TokenValidationFailException.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/exception/TokenValidationFailException.java
@@ -1,0 +1,9 @@
+package oz.bookiarybacked.exception;
+
+public class TokenValidationFailException extends RuntimeException {
+
+	public TokenValidationFailException(String message) {
+		super(message);
+	}
+
+}

--- a/bookiary-infrastructure/build.gradle
+++ b/bookiary-infrastructure/build.gradle
@@ -2,5 +2,13 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    // Rest Client
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     implementation project(':bookiary-domain')
 }

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/PropertyConfig.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/PropertyConfig.java
@@ -1,0 +1,9 @@
+package oz.bookiarybacked.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan
+public class PropertyConfig {
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/properties/KakaoOAuthProperties.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/properties/KakaoOAuthProperties.java
@@ -1,0 +1,14 @@
+package oz.bookiarybacked.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("oauth.kakao")
+public record KakaoOAuthProperties(
+	String authorizationCodeRequestUri,
+	String tokenRequestUri,
+	String clientId,
+	String redirectUri,
+	String tokenInfoRequestUri,
+	String clientSecret
+) {
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/RestClientKakaoApiService.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/RestClientKakaoApiService.java
@@ -7,9 +7,9 @@ import org.springframework.web.client.RestClient;
 
 import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.infra.auth.oauth.kakao.KakaoApiService;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenReqBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenRes;
 
 @Service
 @RequiredArgsConstructor
@@ -19,21 +19,21 @@ public class RestClientKakaoApiService implements KakaoApiService {
 	private static final RestClient REST_CLIENT = RestClient.create();
 
 	@Override
-	public TokenResponse sendAccessTokenRequest(TokenRequestBody body, String tokenRequestBaseUri) {
+	public AccessTokenRes sendAccessTokenRequest(AccessTokenReqBody body, String tokenRequestBaseUri) {
 		return REST_CLIENT.post()
 			.uri(tokenRequestBaseUri)
 			.contentType(APPLICATION_FORM_URLENCODED)
 			.body(body.toMap())
 			.retrieve()
-			.body(TokenResponse.class);
+			.body(AccessTokenRes.class);
 	}
 
 	@Override
-	public TokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri) {
+	public AccessTokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri) {
 		return REST_CLIENT.get()
 			.uri(tokenInfoRequestUri)
 			.header(AUTHORIZATION, TOKEN_PREFIX + accessToken)
 			.retrieve()
-			.body(TokenInfo.class);
+			.body(AccessTokenInfo.class);
 	}
 }

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/RestClientKakaoApiService.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/RestClientKakaoApiService.java
@@ -1,0 +1,39 @@
+package oz.bookiarybacked.infra.api;
+
+import static org.springframework.http.MediaType.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.infra.auth.oauth.kakao.KakaoApiService;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+
+@Service
+@RequiredArgsConstructor
+public class RestClientKakaoApiService implements KakaoApiService {
+	private static final String AUTHORIZATION = "Authorization";
+	private static final String TOKEN_PREFIX = "Bearer ";
+	private static final RestClient REST_CLIENT = RestClient.create();
+
+	@Override
+	public TokenResponse sendAccessTokenRequest(TokenRequestBody body, String tokenRequestBaseUri) {
+		return REST_CLIENT.post()
+			.uri(tokenRequestBaseUri)
+			.contentType(APPLICATION_FORM_URLENCODED)
+			.body(body.toMap())
+			.retrieve()
+			.body(TokenResponse.class);
+	}
+
+	@Override
+	public TokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri) {
+		return REST_CLIENT.get()
+			.uri(tokenInfoRequestUri)
+			.header(AUTHORIZATION, TOKEN_PREFIX + accessToken)
+			.retrieve()
+			.body(TokenInfo.class);
+	}
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/OAuthManagerFactoryImpl.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/OAuthManagerFactoryImpl.java
@@ -1,0 +1,31 @@
+package oz.bookiarybacked.infra.auth.oauth;
+
+import static java.util.function.UnaryOperator.*;
+import static java.util.stream.Collectors.*;
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+import oz.bookiarybacked.domain.auth.service.OAuthManager;
+import oz.bookiarybacked.domain.auth.service.OAuthManagerFactory;
+
+@Component
+public class OAuthManagerFactoryImpl implements OAuthManagerFactory {
+	private final Map<AuthProviderType, OAuthManager> typeToManager;
+
+	public OAuthManagerFactoryImpl(Map<String, OAuthManager> managers) {
+		typeToManager = managers.values()
+			.stream()
+			.collect(toMap(OAuthManager::getType, identity()));
+	}
+
+	@Override
+	public OAuthManager getOAuthManager(AuthProviderType type) {
+		return Optional.ofNullable(typeToManager.get(type))
+			.orElseThrow(() -> new RuntimeException(UNSUPPORTED_OAUTH_TYPE));
+	}
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoApiService.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoApiService.java
@@ -1,0 +1,11 @@
+package oz.bookiarybacked.infra.auth.oauth.kakao;
+
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+
+public interface KakaoApiService {
+	TokenResponse sendAccessTokenRequest(TokenRequestBody body, String uri);
+
+	TokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri);
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoApiService.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoApiService.java
@@ -1,11 +1,11 @@
 package oz.bookiarybacked.infra.auth.oauth.kakao;
 
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenReqBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenRes;
 
 public interface KakaoApiService {
-	TokenResponse sendAccessTokenRequest(TokenRequestBody body, String uri);
+	AccessTokenRes sendAccessTokenRequest(AccessTokenReqBody body, String uri);
 
-	TokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri);
+	AccessTokenInfo sendTokenInfoRequest(String accessToken, String tokenInfoRequestUri);
 }

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoOAuthManager.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoOAuthManager.java
@@ -13,9 +13,9 @@ import oz.bookiarybacked.config.properties.KakaoOAuthProperties;
 import oz.bookiarybacked.domain.auth.dto.OAuthUser;
 import oz.bookiarybacked.domain.auth.model.AuthProviderType;
 import oz.bookiarybacked.domain.auth.service.OAuthManager;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
-import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenReqBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.AccessTokenRes;
 
 @Component
 public class KakaoOAuthManager implements OAuthManager {
@@ -65,16 +65,16 @@ public class KakaoOAuthManager implements OAuthManager {
 	@Override
 	public OAuthUser retrieveOAuthUser(String code) {
 		// Step 1. 인증 서버에서 AT 발급
-		TokenResponse response = kaKaoApiService.sendAccessTokenRequest(buildTokenRequestBody(code), tokenRequestUri);
+		AccessTokenRes response = kaKaoApiService.sendAccessTokenRequest(buildTokenRequestBody(code), tokenRequestUri);
 		String accessToken = response.accessToken();
 
 		// Step 2. AT로 사용자 정보 요청
-		TokenInfo tokenInfo = kaKaoApiService.sendTokenInfoRequest(accessToken, tokenInfoRequestUri);
-		return OAuthUser.of(KAKAO, String.valueOf(tokenInfo.memberId()));
+		AccessTokenInfo accessTokenInfo = kaKaoApiService.sendTokenInfoRequest(accessToken, tokenInfoRequestUri);
+		return OAuthUser.of(KAKAO, String.valueOf(accessTokenInfo.memberId()));
 	}
 
-	private TokenRequestBody buildTokenRequestBody(String code) {
-		return TokenRequestBody.builder()
+	private AccessTokenReqBody buildTokenRequestBody(String code) {
+		return AccessTokenReqBody.builder()
 			.grantType(AUTHORIZATION_CODE)
 			.clientId(clientId)
 			.redirectUri(redirectUri)

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoOAuthManager.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/KakaoOAuthManager.java
@@ -1,0 +1,92 @@
+package oz.bookiarybacked.infra.auth.oauth.kakao;
+
+import static oz.bookiarybacked.domain.auth.model.AuthProviderType.*;
+
+import java.net.URI;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import oz.bookiarybacked.config.properties.KakaoOAuthProperties;
+import oz.bookiarybacked.domain.auth.dto.OAuthUser;
+import oz.bookiarybacked.domain.auth.model.AuthProviderType;
+import oz.bookiarybacked.domain.auth.service.OAuthManager;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenInfo;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenRequestBody;
+import oz.bookiarybacked.infra.auth.oauth.kakao.dto.TokenResponse;
+
+@Component
+public class KakaoOAuthManager implements OAuthManager {
+	private static final String AUTHORIZATION_CODE = "authorization_code";
+	private final KakaoApiService kaKaoApiService;
+	private final String authorizationCodeRequestUri;
+	private final String tokenRequestUri;
+	private final String tokenInfoRequestUri;
+	private final String clientId;
+	private final String redirectUri;
+	private final String clientSecret;
+
+	public KakaoOAuthManager(KakaoApiService kakaoApiService, KakaoOAuthProperties properties) {
+		this.kaKaoApiService = kakaoApiService;
+		this.authorizationCodeRequestUri = properties.authorizationCodeRequestUri();
+		this.tokenRequestUri = properties.tokenRequestUri();
+		this.clientId = properties.clientId();
+		this.redirectUri = properties.redirectUri();
+		this.tokenInfoRequestUri = properties.tokenInfoRequestUri();
+		this.clientSecret = properties.clientSecret();
+	}
+
+	@Override
+	public AuthProviderType getType() {
+		return KAKAO;
+	}
+
+	/**
+	 * 카카오 로그인 페이지 URL 생성
+	 * cf) https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
+	 */
+	@Override
+	public URI getLoginPageUrl() {
+		return UriComponentsBuilder
+			.fromUriString(authorizationCodeRequestUri)
+			.queryParam("response_type", "code")
+			.queryParam("client_id", clientId)
+			.queryParam("redirect_uri", redirectUri)
+			.build()
+			.toUri();
+	}
+
+	/**
+	 * 액세스 토큰(AT) 요청
+	 * cf) https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+	 */
+	@Override
+	public OAuthUser retrieveOAuthUser(String code) {
+		// Step 1. 인증 서버에서 AT 발급
+		TokenResponse response = kaKaoApiService.sendAccessTokenRequest(buildTokenRequestBody(code), tokenRequestUri);
+		String accessToken = response.accessToken();
+
+		// Step 2. AT로 사용자 정보 요청
+		TokenInfo tokenInfo = kaKaoApiService.sendTokenInfoRequest(accessToken, tokenInfoRequestUri);
+		return OAuthUser.of(KAKAO, String.valueOf(tokenInfo.memberId()));
+	}
+
+	private TokenRequestBody buildTokenRequestBody(String code) {
+		return TokenRequestBody.builder()
+			.grantType(AUTHORIZATION_CODE)
+			.clientId(clientId)
+			.redirectUri(redirectUri)
+			.code(code)
+			.clientSecret(clientSecret)
+			.build();
+	}
+
+	private Claims parseJwt(String token) {
+		return Jwts.parserBuilder()
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenInfo.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenInfo.java
@@ -2,7 +2,7 @@ package oz.bookiarybacked.infra.auth.oauth.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record TokenInfo(
+public record AccessTokenInfo(
 	@JsonProperty("id")
 	long memberId,
 	@JsonProperty("expires_in")

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenReqBody.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenReqBody.java
@@ -6,7 +6,7 @@ import org.springframework.util.MultiValueMap;
 import lombok.Builder;
 
 @Builder
-public record TokenRequestBody(
+public record AccessTokenReqBody(
 	String grantType,
 	String clientId,
 	String redirectUri,

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenRes.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/AccessTokenRes.java
@@ -2,7 +2,7 @@ package oz.bookiarybacked.infra.auth.oauth.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record TokenResponse(
+public record AccessTokenRes(
 	@JsonProperty("token_type")
 	String tokenType,
 	@JsonProperty("access_token")

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenInfo.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenInfo.java
@@ -1,0 +1,13 @@
+package oz.bookiarybacked.infra.auth.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenInfo(
+	@JsonProperty("id")
+	long memberId,
+	@JsonProperty("expires_in")
+	int expiresIn,
+	@JsonProperty("app_id")
+	int appId
+) {
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenRequestBody.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenRequestBody.java
@@ -1,0 +1,26 @@
+package oz.bookiarybacked.infra.auth.oauth.kakao.dto;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import lombok.Builder;
+
+@Builder
+public record TokenRequestBody(
+	String grantType,
+	String clientId,
+	String redirectUri,
+	String code,
+	String clientSecret
+) {
+
+	public MultiValueMap<String, String> toMap() {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add("grant_type", grantType);
+		map.add("client_id", clientId);
+		map.add("redirect_uri", redirectUri);
+		map.add("code", code);
+		map.add("client_secret", clientSecret);
+		return map;
+	}
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenResponse.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/auth/oauth/kakao/dto/TokenResponse.java
@@ -1,0 +1,21 @@
+package oz.bookiarybacked.infra.auth.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenResponse(
+	@JsonProperty("token_type")
+	String tokenType,
+	@JsonProperty("access_token")
+	String accessToken,
+	@JsonProperty("id_token")
+	String idToken,
+	@JsonProperty("expires_in")
+	int expiresIn,
+	@JsonProperty("refresh_token")
+	String refreshToken,
+	@JsonProperty("refresh_token_expires_in")
+	int refreshTokenExpiresIn,
+	@JsonProperty("scope")
+	String scope
+) {
+}

--- a/bookiary-presentation/build.gradle
+++ b/bookiary-presentation/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 예외처리 때문에 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 

--- a/bookiary-presentation/build.gradle
+++ b/bookiary-presentation/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // 예외처리 때문에 추가
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -16,5 +17,6 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     implementation project(':bookiary-application')
+    implementation project(':bookiary-domain')
     implementation project(':bookiary-infrastructure')
 }

--- a/bookiary-presentation/build.gradle
+++ b/bookiary-presentation/build.gradle
@@ -16,4 +16,5 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     implementation project(':bookiary-application')
+    implementation project(':bookiary-infrastructure')
 }

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/annotation/Login.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/annotation/Login.java
@@ -1,0 +1,12 @@
+package oz.bookiarybacked.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/config/SecurityConfig.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package oz.bookiarybacked.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.filter.AccessTokenValidationFilter;
+import oz.bookiarybacked.filter.AuthExceptionHandlerFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AccessTokenValidationFilter accessTokenValidationFilter;
+	private final AuthExceptionHandlerFilter authExceptionHandlerFilter;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+		return httpSecurity
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.headers(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.rememberMe(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+			.addFilterBefore(accessTokenValidationFilter, BasicAuthenticationFilter.class)
+			.addFilterBefore(authExceptionHandlerFilter, AccessTokenValidationFilter.class)
+			.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("*"));
+		configuration.setAllowedMethods(
+			Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+		);
+		configuration.setAllowedHeaders(List.of("*"));
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}
+

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/config/WebConfig.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/config/WebConfig.java
@@ -1,0 +1,19 @@
+package oz.bookiarybacked.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import oz.bookiarybacked.resolver.LoginArgumentResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new LoginArgumentResolver());
+	}
+
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/exception/ForbiddenException.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+	public ForbiddenException(String message) {
+		super(message);
+	}
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/filter/AccessTokenValidationFilter.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/filter/AccessTokenValidationFilter.java
@@ -1,0 +1,59 @@
+package oz.bookiarybacked.filter;
+
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.domain.auth.service.JwtManager;
+import oz.bookiarybacked.exception.TokenValidationFailException;
+
+@Component
+@RequiredArgsConstructor
+public class AccessTokenValidationFilter extends OncePerRequestFilter {
+
+	public static final String JWT_HEADER = "Authorization";
+	public static final String JWT_PREFIX = "Bearer ";
+
+	private final JwtManager jwtManager;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String bearerToken = request.getHeader(JWT_HEADER);
+		String accessToken = resolveToken(bearerToken);
+
+		if (null != accessToken) {
+			try {
+				Long userId = jwtManager.getUserId(accessToken);
+				Authentication auth = new UsernamePasswordAuthenticationToken(userId, null);
+				SecurityContextHolder.getContext().setAuthentication(auth);
+			} catch (Exception e) {
+				throw new TokenValidationFailException(INVALID_TOKEN);
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(String bearerToken) {
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(JWT_PREFIX)) {
+			return bearerToken.substring(JWT_PREFIX.length());
+		}
+
+		return null;
+	}
+
+}
+

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/filter/AuthExceptionHandlerFilter.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/filter/AuthExceptionHandlerFilter.java
@@ -1,0 +1,46 @@
+package oz.bookiarybacked.filter;
+
+import static java.nio.charset.StandardCharsets.*;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.util.MimeTypeUtils.*;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import oz.bookiarybacked.presentation.api.ApiResult;
+
+@Slf4j
+@Component
+public class AuthExceptionHandlerFilter extends OncePerRequestFilter {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (AuthenticationException e) {
+			log.debug(e.getMessage(), e.fillInStackTrace());
+
+			response.setContentType(APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding(UTF_8.name());
+			response.setStatus(UNAUTHORIZED.value());
+
+			ApiResult<Void> body = ApiResult.error(UNAUTHORIZED, e.getMessage());
+
+			response.getWriter().write(objectMapper.writeValueAsString(body));
+		}
+	}
+
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/ApiResult.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/ApiResult.java
@@ -1,0 +1,42 @@
+package oz.bookiarybacked.presentation.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * API 응답을 표준화하기 위한 제네릭 레코드(Record)
+ *
+ * 이 클래스는 API 응답에서 반환되는 상태 코드, 상태 메시지, 응답 데이터 등을 포함하여
+ * 일관된 응답 형식을 제공하기 위해 설계되었습니다.
+ */
+public record ApiResult<T>(
+	int code,
+	HttpStatus status,
+	String message,
+	T data
+) {
+	private ApiResult(HttpStatus status, String message, T data) {
+		this(status.value(), status, message, data);
+	}
+
+	public static <T> ApiResult<T> of(HttpStatus httpStatus, String message, T data) {
+		return new ApiResult<>(httpStatus, message, data);
+	}
+
+	public static <T> ApiResult<T> of(HttpStatus httpStatus, T data) {
+		return of(httpStatus, httpStatus.name(), data);
+	}
+
+	public static ApiResult<Void> of(HttpStatus httpStatus) {
+		return new ApiResult<>(httpStatus, httpStatus.name(), null);
+	}
+
+	public static <T> ApiResult<T> ok(T data) {
+		return of(OK, data);
+	}
+
+	public static <T> ApiResult<T> error(HttpStatus httpStatus, String message) {
+		return new ApiResult<>(httpStatus, message, null);
+	}
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
@@ -7,12 +7,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.application.auth.AuthService;
+import oz.bookiarybacked.application.auth.dto.request.ReissueTokenReq;
 import oz.bookiarybacked.application.auth.dto.response.LoginRes;
 
 @RestController
@@ -52,6 +55,21 @@ public class AuthApiController {
 		@RequestParam String code
 	) {
 		LoginRes response = authService.socialLogin(provider, code);
+		ApiResult<LoginRes> result = ApiResult.ok(response);
+
+		return ResponseEntity.ok(result);
+	}
+
+	/**
+	 * 액세스 토큰 재발급을 처리하는 메서드 (자동 로그인)
+	 * @param request 자동 로그인 요청 (Refresh Token)
+	 * @return 자동 로그인 응답 (Access Token / Refresh Token)
+	 */
+	@PostMapping("/auth/reissue")
+	public ResponseEntity<ApiResult<LoginRes>> reissue(
+		@RequestBody @Valid ReissueTokenReq request
+	) {
+		LoginRes response = authService.reissue(request);
 		ApiResult<LoginRes> result = ApiResult.ok(response);
 
 		return ResponseEntity.ok(result);

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
@@ -1,0 +1,59 @@
+package oz.bookiarybacked.presentation.api;
+
+import java.net.URI;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.application.auth.AuthService;
+import oz.bookiarybacked.application.auth.dto.response.LoginRes;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthApiController {
+
+	private final AuthService authService;
+
+	/**
+	 * 소셜 로그인 페이지로 리다이렉트하는 메서드 (ex. 카카오 로그인 페이지)
+	 * @param provider OAuth 제공자
+	 *  - 카카오: /api/oauth/kakao (🔗: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)
+	 */
+	@GetMapping("/oauth/{provider}")
+	public ResponseEntity<ApiResult<Void>> getLoginPage(
+		@PathVariable String provider
+	) {
+		URI redirectUri = authService.getLoginUrl(provider);
+		ApiResult<Void> result = ApiResult.of(HttpStatus.FOUND);
+
+		return ResponseEntity
+			.status(HttpStatus.FOUND)
+			.location(redirectUri)
+			.body(result);
+	}
+
+	/**
+	 * 로그인 요청을 처리하는 메서드
+	 * @param provider OAuth 제공자
+	 * @param code OAuth 인증 코드
+	 * @return 로그인 응답 (Access Token / Refresh Token)
+	 */
+	@PostMapping("/oauth/{provider}/login")
+	public ResponseEntity<ApiResult<LoginRes>> socialLogin(
+		@PathVariable String provider,
+		@RequestParam String code
+	) {
+		LoginRes response = authService.socialLogin(provider, code);
+		ApiResult<LoginRes> result = ApiResult.ok(response);
+
+		return ResponseEntity.ok(result);
+	}
+}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/GlobalExceptionHandler.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package oz.bookiarybacked.presentation.exception;
+package oz.bookiarybacked.presentation.api;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -13,7 +13,7 @@ import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import oz.bookiarybacked.presentation.api.ApiResult;
+import oz.bookiarybacked.exception.ForbiddenException;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.badRequest()
 			.body(result);
 	}
-	
+
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResult<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
 		log.debug(e.getMessage(), e.fillInStackTrace());
@@ -51,6 +51,17 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity
 			.status(NOT_FOUND)
+			.body(result);
+	}
+
+	@ExceptionHandler(ForbiddenException.class)
+	public ResponseEntity<ApiResult<Void>> handleForbiddenException(ForbiddenException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(FORBIDDEN, e.getMessage());
+
+		return ResponseEntity
+			.status(FORBIDDEN)
 			.body(result);
 	}
 

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/exception/GlobalExceptionHandler.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,91 @@
+package oz.bookiarybacked.presentation.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import oz.bookiarybacked.presentation.api.ApiResult;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalExceptionHandler {
+
+	/**
+	 * 4XX 에러 처리
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResult<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(HttpStatus.BAD_REQUEST, extractErrorMessages(e));
+
+		return ResponseEntity.badRequest()
+			.body(result);
+	}
+	
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ApiResult<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(BAD_REQUEST, e.getMessage());
+
+		return ResponseEntity.badRequest()
+			.body(result);
+	}
+
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<ApiResult<Void>> handleEntityNotFoundException(EntityNotFoundException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(NOT_FOUND, e.getMessage());
+
+		return ResponseEntity
+			.status(NOT_FOUND)
+			.body(result);
+	}
+
+	@ExceptionHandler(EntityExistsException.class)
+	public ResponseEntity<ApiResult<Void>> handleEntityExistsException(EntityExistsException e) {
+		log.debug(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(CONFLICT, e.getMessage());
+
+		return ResponseEntity
+			.status(CONFLICT)
+			.body(result);
+	}
+
+	/**
+	 * 5XX 에러 처리
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResult<Void>> handleException(Exception e) {
+		log.error(e.getMessage(), e.fillInStackTrace());
+
+		ApiResult<Void> result = ApiResult.error(INTERNAL_SERVER_ERROR, e.getMessage());
+
+		return ResponseEntity
+			.status(INTERNAL_SERVER_ERROR)
+			.body(result);
+	}
+
+	private String extractErrorMessages(MethodArgumentNotValidException e) {
+		return e.getBindingResult()
+			.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.toList()
+			.toString();
+	}
+}
+

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/resolver/LoginArgumentResolver.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/resolver/LoginArgumentResolver.java
@@ -1,0 +1,42 @@
+package oz.bookiarybacked.resolver;
+
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import oz.bookiarybacked.annotation.Login;
+import oz.bookiarybacked.exception.ForbiddenException;
+
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+		boolean hasLongType = parameter.getParameterType()
+			.equals(Long.class);
+
+		return hasLoginAnnotation && hasLongType;
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		Authentication authentication = SecurityContextHolder.getContext()
+			.getAuthentication();
+
+		if (authentication != null && authentication.getPrincipal() instanceof Long) {
+			return authentication.getPrincipal(); // 사용자가 로그인한 경우, 로그인 ID 반환
+		}
+
+		throw new ForbiddenException(LOGIN_REQUIRED); // 로그인하지 않은 경우, 예외 발생
+	}
+
+}

--- a/bookiary-presentation/src/main/resources/application-example.yml
+++ b/bookiary-presentation/src/main/resources/application-example.yml
@@ -17,3 +17,18 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+
+jwt:
+  issuer: issuer
+  secret-key: secret-key
+  expires_in: 60 # 60분
+  refresh-expires_in: 10080 # 7일 (7*24*60)
+
+oauth:
+  kakao:
+    authorization_code_request_uri: https://kauth.kakao.com/oauth/authorize
+    token_request_uri: https://kauth.kakao.com/oauth/token
+    token_info_request_uri: https://kapi.kakao.com/v1/user/access_token_info
+    client_id: client_id
+    redirect_uri: redirect_uri
+    client_secret: client_secret

--- a/bookiary-presentation/src/test/resources/application.yml
+++ b/bookiary-presentation/src/test/resources/application.yml
@@ -8,3 +8,9 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create-drop
+
+jwt:
+  issuer: issuer
+  secret-key: 78c1411b9579068358fa217f4f006054990c1792fe6e2a3a642c81db73d5d0b0ee1eb2djhfuhufjwdnajkshuaqibjh
+  expires_in: 60
+  refresh-expires_in: 10080

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ subprojects {
     apply plugin: 'org.springframework.boot'
 
     dependencies {
+        // Spring Boot
+        implementation 'org.springframework.boot:spring-boot-starter'
+
         // Lombok
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #4 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- `User`, `AuthProvider`, `RefreshToken` 엔티티 생성 (추후 ddl 스크립트로 변경 예정)
- 카카오 소셜 로그인 구현

## 💬 고민한 점
### OAuth2 로그인 방식을 선택한 이유
OAuth2 로그인 방식을 사용하면 간편한 회원가입과 로그인으로 사용자 편의성이 향상되고, 서버에서는 비밀번호를 따로 관리하지 않아도 돼 보안이 강화된다는 장점이 있습니다. 또한, OAuth2 제공자가 지원하는 보안 혜택을 누릴 수 있기 때문에 OAuth2 로그인 방식을 선택했습니다.

물론, OAuth2 제공자에 대한 의존성이 단점이 될 수 있습니다. 현재 카카오 로그인만 제공하고 있기 때문에, 카카오 계정이 없는 유저는 회원가입을 할 수 없습니다. 하지만, 카카오는 대부분의 한국인이 사용을 하고 있는 서비스인 만큼 이로 인한 단점보다는 장점이 크다고 생각하여 결정했습니다.
 
### 토큰 기반 인증 방식을 선택한 이유 (Session vs JWT)
세션 기반 인증 방식은 서버에서 세션 정보를 관리하는 Stateful 한 특징이 존재하기 때문에 확장성이 떨어진다는 단점이 있습니다. 세션 클러스터링을 통해 세션을 Stateless하게 관리할 수도 있지만, 세션 스토리지가 단일 장애 지점(SPOF)이 될 수 있고, 이 문제를 해결하기 위해 다중화를 도입하게 된다면 시스템 복잡성이 늘어난다는 단점이 있었습니다.

토큰 기반 인증 방식은 클라이언트에서 세션 정보를 관리하는 Stateless 한 특징으로 인해 서버에 부하를 적게 주며 확장성이 높다는 장점이 있습니다. 하지만, 클라이언트에서 토큰을 관리하기 때문에 보안에 더 취약할 수 있으며, 모든 요청에 토큰 정보를 포함해야 하기 때문에 헤더의 크기가 커지는 단점이 존재합니다.

세션 기반 인증 방식과 토큰 기반 인증 방식의 장단점을 비교한 결과, 추후 트래픽이 증가하여 분산 환경이 되었을 때 확장성이 더 좋은 JWT 기반 인증 방식을 결정했습니다.

### 카카오 로그인 플로우 차트
<img width="1255" alt="스크린샷 2024-09-24 22 13 29" src="https://github.com/user-attachments/assets/874c6135-d0a6-4c6e-8e91-51a6187aa9d6">

👩🏻‍💻 인증코드(AuthCode)를 프론트엔드로 보낼지, 백엔드로 보낼지에 대한 고민이 있었습니다! 백엔드로 보낼경우 로그인 완료 응답을 Redirect 로 내려줘야 하는데, 그렇게 되면 AT/RT가 쿼리스트링으로 노출이 된다는 단점(바디에 데이터를 넣을 수 없어서)이 있어서, 프론트엔드로 보내는 방식으로 결정했습니다!
🔗 [참고](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)

### 카카오 로그인 외부 API 요청 방식
Spring에서 외부 API를 호출하는 방식에는 `RestTemplate`, `WebClient`, `OpenFeign`, `RestClient` 가 있었습니다!
먼저 유일한 비동기를 지원하는 방식인 `WebClient`의 경우, _카카오 로그인이 비동기가 필요한가?_ (항상 동기식으로 동작) 라는 생각이 들어 제외하였고,  `OpenFeign`은 더이상 업데이트가 되지 않는다고 명시되어 있고, Spring 에서 공식적으로 `RestTemplate` 보다 `RestClient`을 권장하고 있기 때문에 `RestClient` 방식을 선택했습니다!
🔗 [참고](https://docs.spring.io/spring-framework/reference/integration/rest-clients.html)

### Refresh Token 도입
액세스 토큰의 보안을 강화하기 위해 만료 기간을 짧게 설정 했습니다. 하지만 짧은 만료 기간으로 인해 재로그인 요청이 빈번해져 사용자 경험이 저하되는 문제가 발생했습니다! 이를 해결하기 위해 재로그인 요청없이 액세스 토큰을 재발급할 수 있도록 리프레시 토큰을 도입했습니다. 
이를 통해 사용자 경험은 향상되었지만, 이로 인해 서버에서 리프레시 토큰을 관리해야 하는 단점이 있었습니다. 하지만 세션 기반 방식과 비교하여, 스토리지에 접근 하는 횟수가 줄어들기 때문에 리프레시 토큰 도입을 결정했습니다!

### Token Rotation을 통한 보안 강화
Refresh Token을 사용해 Access Token만 재발급받는 경우, Refresh Token은 바뀌지 않고 그대로 유지됩니다. 이는 탈취된 Refresh Token이 지속적으로 사용될 수 있는 보안 위험이 있습니다. 이 문제를 해결하기 위해 토큰 재발급 요청 시, 서버는 새로운 Access Token과 함께 새로운 Refresh Token을 반환합니다. 이후, 클라이언트는 새로 발급된 Refresh Token만을 사용할 수 있어 보안이 강화되었습니다.


