### PR TITLE
[feat] 책 저장하기

### DIFF
--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/book/BookService.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/book/BookService.java
@@ -1,0 +1,47 @@
+package oz.bookiarybacked.application.book;
+
+import static oz.bookiarybacked.exception.ErrorMessages.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.application.infra.BookSearchService;
+import oz.bookiarybacked.domain.book.dto.BookDto;
+import oz.bookiarybacked.domain.book.model.Book;
+import oz.bookiarybacked.domain.book.repository.BookRepository;
+import oz.bookiarybacked.domain.user.model.User;
+import oz.bookiarybacked.domain.user.model.UserBook;
+import oz.bookiarybacked.domain.user.repository.UserBookRepository;
+import oz.bookiarybacked.domain.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookService {
+	private final BookRepository bookRepository;
+	private final BookSearchService bookSearchService;
+	private final UserRepository userRepository;
+	private final UserBookRepository userBookRepository;
+
+	@Transactional
+	public void addBookToShelf(Long userId, String isbn) {
+		// Step 1. 책 정보 조회
+		Book book = bookRepository.findByIsbn(isbn).orElseGet(
+			() -> {
+				BookDto bookInfo = bookSearchService.search(isbn);
+				Book newBook = Book.from(bookInfo);
+				return bookRepository.save(newBook);
+			}
+		);
+
+		// Step 2. 로그인 사용자 조회
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+		// Step 3. 책을 책장에 추가
+		UserBook userBook = user.addBook(book);
+		userBookRepository.save(userBook);
+	}
+}

--- a/bookiary-application/src/main/java/oz/bookiarybacked/application/infra/BookSearchService.java
+++ b/bookiary-application/src/main/java/oz/bookiarybacked/application/infra/BookSearchService.java
@@ -1,9 +1,11 @@
-package oz.bookiarybacked.application.book;
+package oz.bookiarybacked.application.infra;
 
-import oz.bookiarybacked.application.book.dto.BookDto;
 import oz.bookiarybacked.application.book.dto.request.BookSearchParam;
 import oz.bookiarybacked.application.common.dto.Page;
+import oz.bookiarybacked.domain.book.dto.BookDto;
 
 public interface BookSearchService {
 	Page<BookDto> search(BookSearchParam searchParam);
+
+	BookDto search(String isbn);
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/common/BaseTimeEntity.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/common/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package oz.bookiarybacked.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+	
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}
+

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/config/JpaConfig.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package oz.bookiarybacked.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/dto/BookDto.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/dto/BookDto.java
@@ -1,4 +1,4 @@
-package oz.bookiarybacked.application.book.dto;
+package oz.bookiarybacked.domain.book.dto;
 
 import lombok.Builder;
 

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/model/Book.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/model/Book.java
@@ -1,0 +1,68 @@
+package oz.bookiarybacked.domain.book.model;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oz.bookiarybacked.common.BaseTimeEntity;
+import oz.bookiarybacked.domain.book.dto.BookDto;
+import oz.bookiarybacked.domain.util.LocalDateUtils;
+
+@Entity
+@Table(name = "book")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "isbn", nullable = false, unique = true)
+	private String isbn;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "author", nullable = false)
+	private String author;
+
+	@Column(name = "publisher", nullable = false)
+	private String publisher;
+
+	@Column(name = "image_url")
+	private String imageUrl;
+
+	@Column(name = "naver_book_url")
+	private String naverBookUrl;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "published_at")
+	private LocalDate publishedAt;
+
+	public static Book from(BookDto bookInfo) {
+		return Book.builder()
+			.isbn(bookInfo.isbn())
+			.title(bookInfo.title())
+			.author(bookInfo.author())
+			.publisher(bookInfo.publisher())
+			.imageUrl(bookInfo.imageUrl())
+			.naverBookUrl(bookInfo.link())
+			.description(bookInfo.description())
+			.publishedAt(LocalDateUtils.toLocalDate(bookInfo.publishedAt()))
+			.build();
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/repository/BookRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/book/repository/BookRepository.java
@@ -1,0 +1,11 @@
+package oz.bookiarybacked.domain.book.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.bookiarybacked.domain.book.model.Book;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+	Optional<Book> findByIsbn(String isbn);
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import oz.bookiarybacked.common.BaseTimeEntity;
 
 @Entity
 @Table(name = "users")
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/User.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import oz.bookiarybacked.common.BaseTimeEntity;
+import oz.bookiarybacked.domain.book.model.Book;
 
 @Entity
 @Table(name = "users")
@@ -32,5 +33,10 @@ public class User extends BaseTimeEntity {
 	public static User signUp() {
 		return User.builder()
 			.build();
+	}
+
+	public UserBook addBook(Book book) {
+		// 책을 책장에 추가하는 비즈니스 로직
+		return UserBook.of(this, book.getId());
 	}
 }

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/UserBook.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/model/UserBook.java
@@ -1,0 +1,44 @@
+package oz.bookiarybacked.domain.user.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oz.bookiarybacked.common.BaseTimeEntity;
+
+@Entity
+@Table(name = "user_book")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBook extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(name = "book_id")
+	private Long bookId;
+
+	public static UserBook of(User user, Long id) {
+		return UserBook.builder()
+			.user(user)
+			.bookId(id)
+			.build();
+	}
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/repository/UserBookRepository.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/user/repository/UserBookRepository.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.bookiarybacked.domain.user.model.UserBook;
+
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+}

--- a/bookiary-domain/src/main/java/oz/bookiarybacked/domain/util/LocalDateUtils.java
+++ b/bookiary-domain/src/main/java/oz/bookiarybacked/domain/util/LocalDateUtils.java
@@ -1,0 +1,16 @@
+package oz.bookiarybacked.domain.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LocalDateUtils {
+
+	public static LocalDate toLocalDate(String yyyyMMdd) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+		return LocalDate.parse(yyyyMMdd, formatter);
+	}
+}

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/properties/NaverSearchProperties.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/config/properties/NaverSearchProperties.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record NaverSearchProperties(
 	String clientId,
 	String clientSecret,
-	String searchRequestUri
+	String searchRequestUri,
+	String searchDetailRequestUri
 ) {
 }

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/dto/response/BookItem.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/dto/response/BookItem.java
@@ -1,6 +1,6 @@
 package oz.bookiarybacked.infra.api.dto.response;
 
-import oz.bookiarybacked.application.book.dto.BookDto;
+import oz.bookiarybacked.domain.book.dto.BookDto;
 
 public record BookItem(
 	String title,

--- a/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/dto/response/BookSearchRes.java
+++ b/bookiary-infrastructure/src/main/java/oz/bookiarybacked/infra/api/dto/response/BookSearchRes.java
@@ -2,8 +2,8 @@ package oz.bookiarybacked.infra.api.dto.response;
 
 import java.util.List;
 
-import oz.bookiarybacked.application.book.dto.BookDto;
 import oz.bookiarybacked.application.common.dto.Page;
+import oz.bookiarybacked.domain.book.dto.BookDto;
 
 public record BookSearchRes(
 	String lastBuildDate,

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/AuthApiController.java
@@ -1,7 +1,9 @@
 package oz.bookiarybacked.presentation.api;
 
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,9 +38,11 @@ public class AuthApiController {
 	) {
 		URI redirectUri = authService.getLoginUrl(provider);
 		ApiResult<Void> result = ApiResult.of(HttpStatus.FOUND);
+		CacheControl cache = CacheControl.maxAge(30, TimeUnit.DAYS).cachePublic(); // 변경이 거의 발생하지 않기 때문에 캐싱 처리 (1달)
 
 		return ResponseEntity
 			.status(HttpStatus.FOUND)
+			.cacheControl(cache)
 			.location(redirectUri)
 			.body(result);
 	}

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/BookApiController.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/BookApiController.java
@@ -3,20 +3,25 @@ package oz.bookiarybacked.presentation.api;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import oz.bookiarybacked.application.book.BookSearchService;
-import oz.bookiarybacked.application.book.dto.BookDto;
+import oz.bookiarybacked.annotation.Login;
+import oz.bookiarybacked.application.book.BookService;
 import oz.bookiarybacked.application.book.dto.request.BookSearchParam;
 import oz.bookiarybacked.application.common.dto.Page;
+import oz.bookiarybacked.application.infra.BookSearchService;
+import oz.bookiarybacked.domain.book.dto.BookDto;
 
 @RestController
 @RequestMapping("/api/books")
 @RequiredArgsConstructor
 public class BookApiController {
 	private final BookSearchService bookSearchService;
+	private final BookService bookService;
 
 	/**
 	 * 책 검색 API
@@ -32,6 +37,24 @@ public class BookApiController {
 
 		return ResponseEntity
 			.status(HttpStatus.OK)
+			.body(result);
+	}
+
+	/**
+	 * 책 저장 API
+	 * @param userId 요청한 사용자 식별자
+	 * @param isbn 저장할 책의 ISBN
+	 */
+	@PostMapping("/{isbn}/save")
+	public ResponseEntity<ApiResult<Void>> addBookToShelf(
+		@Login Long userId,
+		@PathVariable String isbn
+	) {
+		bookService.addBookToShelf(userId, isbn);
+		ApiResult<Void> result = ApiResult.of(HttpStatus.CREATED);
+
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
 			.body(result);
 	}
 }

--- a/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/BookApiController.java
+++ b/bookiary-presentation/src/main/java/oz/bookiarybacked/presentation/api/BookApiController.java
@@ -13,7 +13,7 @@ import oz.bookiarybacked.application.book.dto.request.BookSearchParam;
 import oz.bookiarybacked.application.common.dto.Page;
 
 @RestController
-@RequestMapping("/api/book")
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
 public class BookApiController {
 	private final BookSearchService bookSearchService;

--- a/bookiary-presentation/src/main/resources/application-example.yml
+++ b/bookiary-presentation/src/main/resources/application-example.yml
@@ -38,3 +38,4 @@ book:
     client-id: client_id
     client-secret: client-secret
     search-request-uri: https://openapi.naver.com/v1/search/book.json
+    search-detail-request-uri: https://openapi.naver.com/v1/search/book_adv.json


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #8 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 책 저장하기 기능 구현

## 💬 고민한 점
### 도서 저장 방식
**자체 DB에 저장하지 않고, 외부 API를 계속 사용하는 방식 (ISBN만 저장)**
- **장점**: 데이터 동기화와 관리가 간편하고, 외부 서비스가 제공하는 최신 데이터를 항상 활용할 수 있다는 장점이 있습니다.
- **단점**: 외부 API에 의존적이기 때문에 외부 API가 느리거나 비정상적일 경우 성능 문제가 발생할 수 있습니다. 또한, API 호출 횟수에 제한이 있기 때문에 추후 트래픽이 늘어나면 문제가 될 수 있다는 단점이 있습니다.

**모든 도서를 우리 DB에 저장하는 방식**
- **장점**: 외부 API 의존도를 줄일 수 있어 외부 API의 변화나 사용 제한에 영향을 덜 받습니다. 또한, 데이터커스터마이징(예: 특정 필드 추가)할 수 있습니다.
- **단점**: 데이터가 오래될 수 있으며, 새로운 도서 정보 업데이트하기 위해 스케줄링이 필요할 수 있습니다. 또한, 초기에 많은 양의 도서를 가져와 저장해야 하는 문제가 있을 수 있습니다.

각 방식의 절충안으로 **사용자가 저장하는 도서만 자체 DB에 저장하고, 도서 검색은 외부 API를 통해 처리하는 방식**을 선택했습니다. 
💡 추후 캐싱을 통해 성능을 개선할 수 있을 것 같습니다!


### Book 테이블에 ISBN을 PK로 하는건 어떨까?
ISBN은 국제적으로 도서를 구분하는 유니크한 식별자이기 때문에 PK로 사용하는 것을 고려했습니다.
- **장점**: 별도의 ID를 생성할 필요가 없고, 쉽게 조회가 가능
- **단점**: ISBN은 일부 변경되거나 새로운 버전이 도입될 가능성도 있기 때문에, 그 경우 FK로서의 안정성이 떨어질 수 있음. 또한, ISBN은 길이가 상대적으로 길어 성능에 영향을 미칠 수 있음

이러한 이유로 **ISBN은 속성으로 저장하되, 내부적으로는 별도의 ID(자동 증가값)를 PK로 사용하는 방법**을 선택했습니다.