### PR TITLE
[feat] 메모 생성하기

### DIFF
--- a/bookiary-api/src/main/java/oz/bookiarybacked/common/exception/ErrorMessages.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/common/exception/ErrorMessages.java
@@ -1,4 +1,4 @@
-package oz.bookiarybacked.exception;
+package oz.bookiarybacked.common.exception;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -13,7 +13,12 @@ public final class ErrorMessages {
 
 	// UserBook
 	public static final String USER_BOOK_NOT_FOUND = "해당 식별자를 가진 책이 존재하지 않습니다.";
+	public static final String USER_BOOK_ALREADY_EXISTS = "이미 책장에 추가된 책입니다.";
+
+	// Note
+	public static final String CONTENT_REQUIRED = "메모의 내용은 필수값입니다.";
 
 	// Common
+	public static final String USER_BOOK_ID_REQUIRED = "사용자 도서 식별자는 필수값입니다.";
 	public static final String PERMISSION_DENIED = "권한이 없습니다.";
 }

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/book/application/BookService.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/book/application/BookService.java
@@ -1,10 +1,11 @@
 package oz.bookiarybacked.domain.book.application;
 
-import static oz.bookiarybacked.exception.ErrorMessages.*;
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.domain.book.domain.dto.BookDto;
@@ -39,7 +40,12 @@ public class BookService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
-		// Step 3. 책을 책장에 추가
+		// Step 3. 책이 이미 책장에 있는지 검사
+		if (userBookRepository.existsByUserIdAndBookId(userId, book.getId())) {
+			throw new EntityExistsException(USER_BOOK_ALREADY_EXISTS);
+		}
+
+		// Step 4. 책을 책장에 추가
 		UserBook userBook = user.addBook(book);
 		userBookRepository.save(userBook);
 	}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/book/application/dto/request/BookSearchParam.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/book/application/dto/request/BookSearchParam.java
@@ -1,7 +1,7 @@
 package oz.bookiarybacked.domain.book.application.dto.request;
 
 import static java.util.Objects.*;
-import static oz.bookiarybacked.exception.ErrorMessages.*;
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
 
 import lombok.Getter;
 import oz.bookiarybacked.common.dto.PageParam;

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/application/BookshelfService.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/application/BookshelfService.java
@@ -1,6 +1,6 @@
 package oz.bookiarybacked.domain.bookshelf.application;
 
-import static oz.bookiarybacked.exception.ErrorMessages.*;
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
 
 import java.util.Objects;
 

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/model/UserBook.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/model/UserBook.java
@@ -1,6 +1,6 @@
 package oz.bookiarybacked.domain.bookshelf.domain.model;
 
-import static oz.bookiarybacked.exception.ErrorMessages.*;
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/model/UserBook.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/model/UserBook.java
@@ -54,4 +54,10 @@ public class UserBook extends BaseTimeEntity {
 			throw new PermissionDeniedException(PERMISSION_DENIED);
 		}
 	}
+
+	public void checkAddNotePermission(long userId) {
+		if (!this.userId.equals(userId)) {
+			throw new PermissionDeniedException(PERMISSION_DENIED);
+		}
+	}
 }

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/repository/UserBookRepository.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/repository/UserBookRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import oz.bookiarybacked.domain.bookshelf.domain.model.UserBook;
 
 public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+	boolean existsByUserIdAndBookId(Long userId, Long id);
 }

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/presentation/api/BookshelfApi.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/presentation/api/BookshelfApi.java
@@ -29,7 +29,7 @@ public class BookshelfApi {
 	 * @param userId 조회할 책장 주인의 식별자
 	 * @param pageParam 페이지 파라미터 (시작 페이지, 페이지 크기)
 	 */
-	@GetMapping("/user/{userId}/bookshelf")
+	@GetMapping("/users/{userId}/bookshelf")
 	public ResponseEntity<ApiResult<Page<BookSummaryDto>>> retrieveBookshelf(
 		@Login Long loginId,
 		@PathVariable Long userId,

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/application/NoteService.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/application/NoteService.java
@@ -1,0 +1,39 @@
+package oz.bookiarybacked.domain.note.application;
+
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.domain.bookshelf.domain.model.UserBook;
+import oz.bookiarybacked.domain.bookshelf.domain.repository.UserBookRepository;
+import oz.bookiarybacked.domain.note.application.dto.request.NoteCreateRequest;
+import oz.bookiarybacked.domain.note.domain.model.Note;
+import oz.bookiarybacked.domain.note.domain.repository.NoteOrderRepository;
+import oz.bookiarybacked.domain.note.domain.repository.NoteRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NoteService {
+	private final NoteRepository noteRepository;
+	private final UserBookRepository userBookRepository;
+	private final NoteOrderRepository noteOrderRepository;
+
+	@Transactional
+	public void create(Long loginId, NoteCreateRequest request) {
+		// Step 1. 도서 조회
+		UserBook book = userBookRepository.findById(request.userBookId())
+			.orElseThrow(() -> new EntityNotFoundException(USER_BOOK_NOT_FOUND));
+
+		// Step 2. 노트 생성 권한 검사
+		book.checkAddNotePermission(loginId);
+
+		// Step 3. 노트 생성
+		int order = noteOrderRepository.getNextOrder(book.getBookId());
+		Note note = Note.of(book.getId(), request.content(), order);
+		noteRepository.save(note);
+	}
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/application/dto/request/NoteCreateRequest.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/application/dto/request/NoteCreateRequest.java
@@ -1,0 +1,14 @@
+package oz.bookiarybacked.domain.note.application.dto.request;
+
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record NoteCreateRequest(
+	@NotNull(message = USER_BOOK_ID_REQUIRED)
+	Long userBookId,
+	@NotBlank(message = CONTENT_REQUIRED)
+	String content
+) {
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/model/Note.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/model/Note.java
@@ -1,0 +1,44 @@
+package oz.bookiarybacked.domain.note.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import oz.bookiarybacked.common.BaseTimeEntity;
+
+@Entity
+@Table(name = "note")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Note extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "user_book_id", nullable = false)
+	private Long userBookId;
+
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "note_order", nullable = false)
+	private int order;
+
+	public static Note of(Long userBookId, String content, int order) {
+		return Note.builder()
+			.userBookId(userBookId)
+			.content(content)
+			.order(order)
+			.build();
+	}
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/repository/NoteOrderRepository.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/repository/NoteOrderRepository.java
@@ -1,0 +1,6 @@
+package oz.bookiarybacked.domain.note.domain.repository;
+
+public interface NoteOrderRepository {
+
+	int getNextOrder(long userBookId);
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/repository/NoteRepository.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/domain/repository/NoteRepository.java
@@ -1,0 +1,8 @@
+package oz.bookiarybacked.domain.note.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import oz.bookiarybacked.domain.note.domain.model.Note;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/presentation/api/NoteApi.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/note/presentation/api/NoteApi.java
@@ -1,0 +1,35 @@
+package oz.bookiarybacked.domain.note.presentation.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.common.presentation.annotation.Login;
+import oz.bookiarybacked.common.presentation.dto.ApiResult;
+import oz.bookiarybacked.domain.note.application.NoteService;
+import oz.bookiarybacked.domain.note.application.dto.request.NoteCreateRequest;
+
+@RestController
+@RequestMapping("/api/notes")
+@RequiredArgsConstructor
+public class NoteApi {
+	private final NoteService noteService;
+
+	@PostMapping
+	public ResponseEntity<ApiResult<Void>> createNote(
+		@Login Long loginId,
+		@Valid @RequestBody NoteCreateRequest request
+	) {
+		noteService.create(loginId, request);
+		ApiResult<Void> result = ApiResult.of(HttpStatus.CREATED);
+
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(result);
+	}
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/user/domain/service/UserDomainService.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/user/domain/service/UserDomainService.java
@@ -1,6 +1,6 @@
 package oz.bookiarybacked.domain.user.domain.service;
 
-import static oz.bookiarybacked.exception.ErrorMessages.*;
+import static oz.bookiarybacked.common.exception.ErrorMessages.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/bookiary-api/src/main/java/oz/bookiarybacked/infra/query/QuerydslNoteOrderRepository.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/infra/query/QuerydslNoteOrderRepository.java
@@ -1,0 +1,28 @@
+package oz.bookiarybacked.infra.query;
+
+import static oz.bookiarybacked.domain.note.domain.model.QNote.*;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import oz.bookiarybacked.domain.note.domain.repository.NoteOrderRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class QuerydslNoteOrderRepository implements NoteOrderRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public int getNextOrder(long userBookId) {
+		return Objects.requireNonNull(
+			queryFactory.select(note.id.count())
+				.from(note)
+				.where(note.userBookId.eq(userBookId))
+				.fetchOne()
+		).intValue();
+	}
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #19 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 메모 생성 기능 구현
- 메모에 순서(note_order) 기능 추가 (추후 확장성을 위해)
- 추가적으로) 책장에 책 저장 시 이미 저장된 책인 경우 예외를 던지도록 변경했습니다!
- 추가적으로) api url은 복수로 구성되도록 변경했습니다!

## 💬 고민한 점
### 노트 순서
노트 순서를 기본적으로 생성 순서로 하기 위해 `NoteOrderRepository`를 만들었습니다. 단순히 생성일 기준으로 정렬할 수 있지만, 추후 확장성을 위해 `note_order` 컬럼을 추가했습니다.