### PR TITLE
[feat] 책 조회 시 노트도 함께 조회하기

### DIFF
--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/application/BookshelfService.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/application/BookshelfService.java
@@ -12,8 +12,8 @@ import lombok.RequiredArgsConstructor;
 import oz.bookiarybacked.common.dto.Page;
 import oz.bookiarybacked.common.dto.PageParam;
 import oz.bookiarybacked.common.exception.PermissionDeniedException;
-import oz.bookiarybacked.domain.bookshelf.domain.dto.BookDetailDto;
 import oz.bookiarybacked.domain.bookshelf.domain.dto.BookSummaryDto;
+import oz.bookiarybacked.domain.bookshelf.domain.dto.response.RetrieveBookRes;
 import oz.bookiarybacked.domain.bookshelf.domain.model.UserBook;
 import oz.bookiarybacked.domain.bookshelf.domain.repository.UserBookQueryRepository;
 import oz.bookiarybacked.domain.bookshelf.domain.repository.UserBookRepository;
@@ -30,7 +30,7 @@ public class BookshelfService {
 		return userBookQueryRepository.retrieveBookshelf(userId, pageParam);
 	}
 
-	public BookDetailDto retrieveBook(Long loginId, Long userBookId) {
+	public RetrieveBookRes retrieveBook(Long loginId, Long userBookId) {
 		UserBook book = userBookRepository.findById(userBookId)
 			.orElseThrow(() -> new EntityNotFoundException(USER_BOOK_NOT_FOUND));
 

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/dto/NoteDto.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/dto/NoteDto.java
@@ -1,0 +1,10 @@
+package oz.bookiarybacked.domain.bookshelf.domain.dto;
+
+import java.time.LocalDateTime;
+
+public record NoteDto(
+	Long id,
+	String content,
+	LocalDateTime createdAt
+) {
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/dto/response/RetrieveBookRes.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/dto/response/RetrieveBookRes.java
@@ -1,0 +1,32 @@
+package oz.bookiarybacked.domain.bookshelf.domain.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import oz.bookiarybacked.domain.bookshelf.domain.dto.BookDetailDto;
+import oz.bookiarybacked.domain.bookshelf.domain.dto.NoteDto;
+
+public record RetrieveBookRes(
+	Long id,
+	String title,
+	String imageUrl,
+	String author,
+	String publisher,
+	LocalDate publishedAt,
+	String description,
+	List<NoteDto> notes
+) {
+
+	public static RetrieveBookRes of(BookDetailDto bookInfo, List<NoteDto> notes) {
+		return new RetrieveBookRes(
+			bookInfo.id(),
+			bookInfo.title(),
+			bookInfo.imageUrl(),
+			bookInfo.author(),
+			bookInfo.publisher(),
+			bookInfo.publishedAt(),
+			bookInfo.description(),
+			notes
+		);
+	}
+}

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/repository/UserBookQueryRepository.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/domain/repository/UserBookQueryRepository.java
@@ -2,11 +2,11 @@ package oz.bookiarybacked.domain.bookshelf.domain.repository;
 
 import oz.bookiarybacked.common.dto.Page;
 import oz.bookiarybacked.common.dto.PageParam;
-import oz.bookiarybacked.domain.bookshelf.domain.dto.BookDetailDto;
 import oz.bookiarybacked.domain.bookshelf.domain.dto.BookSummaryDto;
+import oz.bookiarybacked.domain.bookshelf.domain.dto.response.RetrieveBookRes;
 
 public interface UserBookQueryRepository {
 	Page<BookSummaryDto> retrieveBookshelf(Long userId, PageParam pageParam);
 
-	BookDetailDto retrieveBook(Long userBookId);
+	RetrieveBookRes retrieveBook(Long userBookId);
 }

--- a/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/presentation/api/BookshelfApi.java
+++ b/bookiary-api/src/main/java/oz/bookiarybacked/domain/bookshelf/presentation/api/BookshelfApi.java
@@ -14,8 +14,8 @@ import oz.bookiarybacked.common.dto.PageParam;
 import oz.bookiarybacked.common.presentation.annotation.Login;
 import oz.bookiarybacked.common.presentation.dto.ApiResult;
 import oz.bookiarybacked.domain.bookshelf.application.BookshelfService;
-import oz.bookiarybacked.domain.bookshelf.domain.dto.BookDetailDto;
 import oz.bookiarybacked.domain.bookshelf.domain.dto.BookSummaryDto;
+import oz.bookiarybacked.domain.bookshelf.domain.dto.response.RetrieveBookRes;
 
 @RestController
 @RequestMapping("/api")
@@ -49,12 +49,12 @@ public class BookshelfApi {
 	 * @param bookId 조회할 사용자 책의 식별자
 	 */
 	@GetMapping("/bookshelf/{bookId}")
-	public ResponseEntity<ApiResult<BookDetailDto>> retrieveBook(
+	public ResponseEntity<ApiResult<RetrieveBookRes>> retrieveBook(
 		@Login Long loginId,
 		@PathVariable Long bookId
 	) {
-		BookDetailDto data = bookshelfService.retrieveBook(loginId, bookId);
-		ApiResult<BookDetailDto> result = ApiResult.ok(data);
+		RetrieveBookRes data = bookshelfService.retrieveBook(loginId, bookId);
+		ApiResult<RetrieveBookRes> result = ApiResult.ok(data);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)


### PR DESCRIPTION
## 🎟️ 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #21 

## 📌 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- 책 조회 시 노트도 함께 조회하도록 변경

## 💬 고민한 점
- join으로 한방 쿼리를 날리려다, 노트에는 따로 순서도 존재하고 리스트로 조회가 되기 때문에 일단 2개의 쿼리로 나눠서 조회했습니다!
